### PR TITLE
npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ubie/ubie-icons-native",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubie-oss/ubie-icons-native.git"
+    "url": "git+https://github.com/ubie-oss/ubie-icons-native.git"
   },
   "version": "1.0.3",
   "description": "Icons used in Ubie native apps.",


### PR DESCRIPTION
Release actionで起こられるので修正した
https://github.com/ubie-oss/ubie-icons-native/actions/runs/12901468327
